### PR TITLE
Switching to lighter image and build config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,10 @@
-FROM ubuntu
+FROM node:8-alpine
 
 RUN \
-	apt-get update && \
-	apt-get install -y \
-	wget \
-	unzip \
-	gnupg
-    
-RUN \
-	wget https://deb.nodesource.com/setup_8.x && \
-	bash setup_8.x
-  
-RUN \
-	apt-get update && \
-	apt-get install -y nodejs
-    
-RUN \
-	wget https://notabug.org/RemixDevs/DeezloaderRemix/archive/master.zip && \
-	unzip master.zip && \
-	cd /deezloaderremix && \
-	bash compileLinux.sh && \
-	cd / && \
-	rm -rf master.zip setup_8.x && \
-  ln -sf /root/.config/Deezloader\ Remix/ /config
+	wget https://notabug.org/RemixDevs/DeezloaderRemix/archive/master.tar.gz && \
+	tar -xvf master.tar.gz && \
+	rm -rf master.tar.gz && \
+	cd /deezloaderremix && npm install && npm run dist:linux -- --dir && \
+	ln -sf /root/.config/Deezloader\ Remix/ /config
 
-CMD \
-	/usr/bin/node /deezloaderremix/app/app.js
+CMD node /deezloaderremix/app/app.js


### PR DESCRIPTION
The build for ia32 architectures fails, but since this image doesn't use the generated AppImages, and just the app inside the Electron container, I used the flag `--dir` to build only the unpacked directory ([more details](https://www.electron.build/cli)).